### PR TITLE
reload zones when they are updated

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -85,6 +85,7 @@ define nsd::zone (
 
   if $content or $source {
     $zonefile = "master/${_filename}"
+    $reload_command = "nsd-control reload ${shell_escape($zone)}"
 
     file { "${::nsd::zonesdir}/${zonefile}":
       ensure       => file,
@@ -95,6 +96,12 @@ define nsd::zone (
       source       => $source,
       validate_cmd => "/usr/sbin/nsd-checkzone ${zone} %",
       before       => ::Concat["${::nsd::conf_dir}/nsd.conf"],
+      notify       => Exec[$reload_command],
+    }
+
+    exec { $reload_command:
+      path        => $::path,
+      refreshonly => true,
     }
   } else {
     $zonefile = "slave/${_filename}"


### PR DESCRIPTION
Simply adds an exec resource to ``nsd::zone`` that runs ``nsd-control reload zonename`` whenever Puppet updates the file or the ``nsd::zone`` resource is a target of a ``notify/subscribe`` relationship.